### PR TITLE
fix for performance issue: consider handlers as available that can only be resolved dynamically

### DIFF
--- a/src/OpenRasta.DI.Windsor.Tests.Unit/MockTypes.cs
+++ b/src/OpenRasta.DI.Windsor.Tests.Unit/MockTypes.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace WindsorDependencyResolver_Specification
+{
+    class DependencyOnTypeWithGernericParams
+    {
+        public String Dependency { get; private set; }
+        
+        public DependencyOnTypeWithGernericParams(String dependency)
+        {
+            Dependency = dependency;
+        }
+    }
+}

--- a/src/OpenRasta.DI.Windsor.Tests.Unit/OpenRasta.DI.Windsor.Tests.Unit.csproj
+++ b/src/OpenRasta.DI.Windsor.Tests.Unit/OpenRasta.DI.Windsor.Tests.Unit.csproj
@@ -57,6 +57,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MockTypes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="WindsorDependencyResolver_Specification.cs" />
   </ItemGroup>

--- a/src/OpenRasta.DI.Windsor.Tests.Unit/WindsorDependencyResolver_Specification.cs
+++ b/src/OpenRasta.DI.Windsor.Tests.Unit/WindsorDependencyResolver_Specification.cs
@@ -10,13 +10,14 @@
 
 #endregion
 
+using System;
+using Castle.MicroKernel.Registration;
 using Castle.Windsor;
-
 using InternalDependencyResolver_Specification;
-
 using NUnit.Framework;
 using OpenRasta.DI;
 using OpenRasta.DI.Windsor;
+using OpenRasta.Testing;
 
 namespace WindsorDependencyResolver_Specification
 {
@@ -32,9 +33,27 @@ namespace WindsorDependencyResolver_Specification
     [TestFixture]
     public class when_registering_dependencies_with_the_castle_resolver : when_registering_dependencies
     {
+
+        readonly WindsorContainer _container = new WindsorContainer();
+        
+
         public override IDependencyResolver CreateResolver()
         {
-            return new WindsorDependencyResolver(new WindsorContainer());
+            return new WindsorDependencyResolver(_container);
+        }
+        
+
+        [Test]
+        public void then_it_should_be_regarded_as_dependency_regardless_of_its_state()
+        {
+            var serviceToBeResolved = typeof(DependencyOnTypeWithGernericParams);
+            const String dynamicDependency = "TestDependency";
+
+            _container.Register(Component.For(serviceToBeResolved)
+                .DynamicParameters((k, d) => d["dependency"] = dynamicDependency));
+              
+            Resolver.HasDependency(serviceToBeResolved).ShouldBe(true);
+            Resolver.Resolve<DependencyOnTypeWithGernericParams>().Dependency.ShouldBe(dynamicDependency);
         }
     }
 

--- a/src/OpenRasta.DI.Windsor/WindsorDependencyResolver.cs
+++ b/src/OpenRasta.DI.Windsor/WindsorDependencyResolver.cs
@@ -148,8 +148,7 @@ namespace OpenRasta.DI.Windsor
         IEnumerable<IHandler> AvailableHandlers(IEnumerable<IHandler> handlers)
         {
             return from handler in handlers
-                   where handler.CurrentState == HandlerState.Valid
-                         && IsAvailable(handler.ComponentModel)
+                   where IsAvailable(handler.ComponentModel)
                    select handler;
         }
 


### PR DESCRIPTION
WindsorDependencyResolver.AvailableHandlers checks among other things
for the CurrentState of a handler to determine its availability.
This is not the best approach, because some handlers can only be
resolved dynamically, e.g. when using DynamicParameters. Those handlers
have the CurrentState "WaitingDependency".
In my case, this causes components registered via OpenRasta to be
registered several times. And since this component is an OpenRasta
Handler, it gets registered with every web-request. This bloats up the
registry and over time slows down the whole application (lookup in a
registry takes longer and longer as it increases).
Checking for the CurrentState is not recommended to be used to check for
available handlers, as also explained here:
http://stackoverflow.com/questions/2732215/how-can-i-validate-the-configuration-of-windsor-castle#tab-top.
I also wrote a test to validate that even if a component might not have
a valid CurrentState, it is still resolveable